### PR TITLE
Change the way to load handlers

### DIFF
--- a/functions/extension.js
+++ b/functions/extension.js
@@ -3,7 +3,7 @@ import parse from 'diffparser'
 import { client } from 'octonode'
 import { updateStatus, validateWebhook } from './utils/github'
 
-export async function checkExtension(event, context, callback) {
+export async function handler(event, context, callback) {
   let response
   const githubClient = client(process.env.GITHUB_TOKEN)
 

--- a/functions/weblate.js
+++ b/functions/weblate.js
@@ -1,7 +1,7 @@
 import { client } from 'octonode'
 import { validateWebhook } from './utils/github'
 
-export async function weblate(event, context, callback) {
+export async function handler(event, context, callback) {
   const githubClient = client(process.env.GITHUB_TOKEN)
 
   const body = JSON.parse(event.body)

--- a/handler.js
+++ b/handler.js
@@ -1,4 +1,0 @@
-import { checkExtension } from './functions/extension'
-import { weblate } from './functions/weblate'
-
-export { checkExtension, weblate }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "handler.js",
   "scripts": {
     "test": "jest",
-    "lint": "eslint functions/ tests/ handler.js"
+    "lint": "eslint functions/ tests/"
   },
   "author": "wallabag <hello@wallabag.org>",
   "license": "MIT",

--- a/serverless.yml
+++ b/serverless.yml
@@ -25,7 +25,7 @@ provider:
 
 functions:
     extension:
-        handler: handler.checkExtension
+        handler: functions/extension.handler
         description: Validate file extensions
         events:
             -
@@ -35,7 +35,7 @@ functions:
                     cors: true
 
     weblate:
-        handler: handler.weblate
+        handler: functions/weblate.handler
         description: Auto label a PR create by Weblate
         events:
             -

--- a/tests/extension.spec.js
+++ b/tests/extension.spec.js
@@ -1,6 +1,6 @@
 import nock from 'nock'
 import { client } from 'octonode'
-import { checkExtension } from '../functions/extension'
+import { handler } from '../functions/extension'
 
 jest.mock('octonode')
 
@@ -11,7 +11,7 @@ describe('Validating GitHub event', () => {
   test('bad event body', async () => {
     const callback = jest.fn()
 
-    await checkExtension({ body: '{}' }, {}, callback)
+    await handler({ body: '{}' }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -36,7 +36,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkExtension({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -61,7 +61,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkExtension({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -86,7 +86,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await checkExtension({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -114,7 +114,7 @@ describe('Validating extension', () => {
       },
     }
 
-    await checkExtension({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -155,7 +155,7 @@ describe('Validating extension', () => {
       },
     }
 
-    await checkExtension({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -198,7 +198,7 @@ describe('Validating extension', () => {
       },
     }
 
-    await checkExtension({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -243,7 +243,7 @@ describe('Validating extension', () => {
       },
     }
 
-    await checkExtension({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -286,7 +286,7 @@ describe('Validating extension', () => {
       },
     }
 
-    await checkExtension({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {

--- a/tests/weblate.spec.js
+++ b/tests/weblate.spec.js
@@ -1,5 +1,5 @@
 import { client } from 'octonode'
-import { weblate } from '../functions/weblate'
+import { handler } from '../functions/weblate'
 
 jest.mock('octonode')
 
@@ -7,7 +7,7 @@ describe('Validating GitHub event', () => {
   test('bad event body', async () => {
     const callback = jest.fn()
 
-    await weblate({ body: '{}' }, {}, callback)
+    await handler({ body: '{}' }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -32,7 +32,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await weblate({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -57,7 +57,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await weblate({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -82,7 +82,7 @@ describe('Validating GitHub event', () => {
       },
     }
 
-    await weblate({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -123,7 +123,7 @@ describe('Apply label', () => {
       },
     }
 
-    await weblate({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {
@@ -161,7 +161,7 @@ describe('Apply label', () => {
       },
     }
 
-    await weblate({ body: JSON.stringify(githubEvent) }, {}, callback)
+    await handler({ body: JSON.stringify(githubEvent) }, {}, callback)
 
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenCalledWith(null, {


### PR DESCRIPTION
When using a single file to load all handlers, there are all loaded when one lambda is invoked. Which might be a problem.
Instead, remove that file and define all loader using their path in the serverless configuration.